### PR TITLE
Creating the Terraform Destroy Workflow

### DIFF
--- a/.github/workflows/terraform-deploy.yml
+++ b/.github/workflows/terraform-deploy.yml
@@ -35,7 +35,7 @@ jobs:
        with: 
           terraform_version: "1.5.0"
 
-     - name: Initialize Terraform
+     - name: Initialise Terraform
        working-directory: ./terraform
        run: terraform init
     

--- a/.github/workflows/terraform-destory.yml
+++ b/.github/workflows/terraform-destory.yml
@@ -1,0 +1,33 @@
+name: Terraform Destroy Workflow
+
+on:
+  workflow_dispatch
+
+jobs:
+  terraform-destroy:
+    runs-on: ubuntu-latest
+
+    steps: 
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
+      - name: Set up Terraform 
+        uses: hashicorp/setup-terraform@v2
+        with: 
+          terraform_version: "1.5.0"
+
+      - name: Initialise Terraform
+        working-directory: ./terraform
+        run: terraform init
+
+      - name: Terraform Destroy
+        working-directory: ./terraform
+        run: |
+           terraform destroy -auto-approve


### PR DESCRIPTION
# Terraform Destroy Workflow

This GitHub Actions workflow is designed to safetly destroy the infrastructure managed by Terraform. It allows users to manually trigger the terraform destroy command to remove resources defined in Terraform configuration files.

**Manual Triggering:** Initiate the destroy process on-demand through the GitHub Actions UI using the `workflow_dispatch` event.

**AWS Credential Configuration:** Securely configure AWS credentials from GitHub Secrets.

**Terraform Setup:** Automatically sets up Terraform before executing any commands.

**Infrastructure Management:** Manages the lifecycle of cloud resources, enabling quick cleanup when resources are no longer needed.

**How to:**
1. Navigate to the Actions tab in your GitHub repository.
2. Select the Terraform Destroy Workflow from the list of workflows.
3. Click the Run workflow button to trigger the destruction of your infrastructure