### PR TITLE
T117 Fix terraform destory pipeline

### DIFF
--- a/.github/workflows/terraform-destory.yml
+++ b/.github/workflows/terraform-destory.yml
@@ -1,11 +1,18 @@
 name: Terraform Destroy Workflow
 
 on:
-  workflow_dispatch
+  workflow_dispatch: 
+    inputs:
+      confirm_destory:
+        description: Type "yes" to confirm infrastructure destruction'
+        required: true 
+        type: string
 
 jobs:
   terraform-destroy:
     runs-on: ubuntu-latest
+
+    if: github.event.inputs.confirm_destroy == 'yes'
 
     steps: 
       - name: Checkout code

--- a/.github/workflows/terraform-destory.yml
+++ b/.github/workflows/terraform-destory.yml
@@ -27,6 +27,14 @@ jobs:
         working-directory: ./terraform
         run: terraform init
 
+      - name: Scale down ECS Service
+        working-directory: ./terraform
+        run: |
+          terraform apply -auto-approve -var="ecs_service_desired_count=0" -target=aws_ecs_service.app_service
+    
+      - name: Wait for scale down
+        run: sleep 30
+
       - name: Terraform Destroy
         working-directory: ./terraform
         run: |


### PR DESCRIPTION
**Description** 

This pull request resolves an issue in the Terraform Destroy workflow that prevented successful deletion of the ECS cluster due to active services. The workflow and Terraform configurations are updated to ensure ECS services are stopped and removed before attempting to delete the ECS cluster. 

Additionally, an extra safety check is added, requiring developers to confirm by typing `yes` before triggering the destroy process. This will prevent accidental deletions and add an extra layer of control over destructive actions.

